### PR TITLE
find RG tag correctly using BamTools API

### DIFF
--- a/parsers.cc
+++ b/parsers.cc
@@ -63,7 +63,7 @@ bool ReadDataVisitor::GatherReadData(const LocalBamToolsUtils::PileupPosition &p
         if(not it->IsCurrentDeletion ){
             int32_t pos_in_alignment = it->PositionInAlignment;
             if (include_site(it->Alignment, pos_in_alignment, m_mapping_cut, qual_cut_char)) {
-                uint32_t sindex = GetSampleIndex(it->Alignment.TagData);
+                uint32_t sindex = GetSampleIndex(it->Alignment);
     
                 if (sindex != MAX_UINT32) {
                     uint16_t bindex = base_index_lookup[(int) it->Alignment.QueryBases[pos_in_alignment]];
@@ -98,7 +98,7 @@ SiteStatsSummary ReadDataVisitor::CalculateStats(const LocalBamToolsUtils::Pileu
         if(not it->IsCurrentDeletion ){
             int32_t pos_in_alignment = it->PositionInAlignment;
             if (include_site(it->Alignment, pos_in_alignment, m_mapping_cut, qual_cut_char)) {            
-                uint32_t sindex = GetSampleIndex(it->Alignment.TagData);
+                uint32_t sindex = GetSampleIndex(it->Alignment);
                 uint16_t bindex = base_index_lookup[(int) it->Alignment.QueryBases[pos_in_alignment]];
                 if ( sindex == mutant_index + 1) {
                     bindex += rotate_by;
@@ -167,18 +167,11 @@ SiteStatsSummary ReadDataVisitor::CalculateStats(const LocalBamToolsUtils::Pileu
 
 }
 
-uint32_t ReadDataVisitor::GetSampleIndex(const std::string &tag_data) {
-    size_t start_index = tag_data.find(RG_TAG);
-    if (start_index != std::string::npos) {
-        start_index += 4;
+uint32_t ReadDataVisitor::GetSampleIndex(const BamAlignment &alignment) {
+    std::string tag_id_2;
+    if (! alignment.GetTag("RG", tag_id_2)) {
+        std::cout << "ERROR: Could not find RG tag in tag data\t" << alignment.TagData << std::endl;
     }
-    else {
-        size_t x = tag_data.find("RG");//TODO: Check for (char)0, RG, Z
-        std::cout << "ERROR: " << tag_data << "\t" << x << std::endl;
-    }
-    size_t end_index = tag_data.find(ZERO_CHAR, start_index);
-    std::string tag_id_2 = tag_data.substr(start_index, (end_index - start_index));
-
     return m_samples[tag_id_2];
 }
 

--- a/parsers.h
+++ b/parsers.h
@@ -60,8 +60,6 @@ public:
 class ReadDataVisitor : public LocalBamToolsUtils::PileupVisitor {
 
 public:
-    const char ZERO_CHAR = ((char) 0);
-    const std::string RG_TAG{{ZERO_CHAR, 'R', 'G', 'Z'}};
     uint64_t region_start = 0;
     uint64_t region_end = -1;
     ReadDataVisitor(LocalBamToolsUtils::Fasta &idx_ref, SampleMap &samples,
@@ -74,8 +72,7 @@ public:
 
     void SetRegion( BedInterval target_region );
 
-    uint32_t GetSampleIndex(const string &tag_data);
-
+    uint32_t GetSampleIndex(const BamTools::BamAlignment &alignment);
 
 protected:
     ModelInput site_data;


### PR DESCRIPTION
accuMUlate uses a homegrown solution to find RG tags attached to reads: using `std::string::find()` to search for the literal string "\000RGZ".  This only works if the previous tag fortuitously ended with \000.

BAM tags containing, e.g., integer values are encoded using a type-sensitive fixed width.  "XS:i:20" is encoded as "XSC\024", with the C indicating a single-byte unsigned int.  In the problem case this was immediately followed by "RGZ..." encoding the tag for the read group.  This is perfectly valid BAM tag encoding, however, the accuMUlate search for "\000RGZ" never found the RG tag for this read or similar reads.

The solution is to use BamTools' own API for finding tags and their values.  It knows about these encodings, and searches for them robustly.  A single call to `BamTools::BamAlignment::GetTag()` will return a tag's value and indicate an error.  The interface to `ReadDataVisitor::GetSampleIndex()` is changed slightly and the function is simplified.  The constants `ReadDataVisitor::RG_TAG` and `ReadDataVisitor::ZERO_CHAR` are removed as they are no longer required.